### PR TITLE
fix: gradle sonar source java version

### DIFF
--- a/workflow-templates/gradle-sonarqube.yml
+++ b/workflow-templates/gradle-sonarqube.yml
@@ -138,4 +138,4 @@ jobs:
               -Dsonar.pullrequest.branch=${{ github.head_ref }}
               -Dsonar.pullrequest.key=${{ github.event.number }}
               -Dsonar.qualitygate.wait=true
-              -Dsonar.java.source=${JAVA_VERSION}
+              -Dsonar.java.source=${{ env.JAVA_VERSION }}


### PR DESCRIPTION
I do actually get on sonar due to the defined java version, see: [PR](https://github.com/myplant-io/energy-management/actions/runs/4627490024/jobs/8185467494)