### PR TITLE
fix: add pwd for docker deploy

### DIFF
--- a/workflow-templates/docker-deploy.yml
+++ b/workflow-templates/docker-deploy.yml
@@ -237,6 +237,7 @@ jobs:
           provenance: false
           push: true
           tags: ${{ steps.aws-login-ecr.outputs.registry }}/${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_TAG_PREFIX }}${{ env.VERSION }}
+          secrets: "nexus_pswd=${{ secrets.NEXUS_MYPLANT_PUBLISHER }}"
 
       - name: Deploy service
         if: env.DEPLOY_TARGETS != 'none'


### PR DESCRIPTION
Add nexus password as secret to docker build step.

Currently we always add it manually.