### PR TITLE
feat: update gh deploy actions

### DIFF
--- a/workflow-templates/dotnet-deploy.yml
+++ b/workflow-templates/dotnet-deploy.yml
@@ -169,6 +169,10 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.0.0-b02
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configurationJson: |
+            {
+              "pr_template": "- #{{TITLE}} (by @#{{AUTHOR}} in ##{{NUMBER}})"
+            }
           outputFile: release_changelog.md
           fromTag: ${{ steps.versioning.outputs.buildFromTag }}
           toTag: ${{ steps.versioning.outputs.relTag }}

--- a/workflow-templates/gradle-deploy.yml
+++ b/workflow-templates/gradle-deploy.yml
@@ -202,6 +202,10 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.0.0-b02
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configurationJson: |
+            {
+              "pr_template": "- #{{TITLE}} (by @#{{AUTHOR}} in ##{{NUMBER}})"
+            }
           outputFile: release_changelog.md
           fromTag: ${{ steps.versioning.outputs.buildFromTag }}
           toTag: ${{ steps.versioning.outputs.relTag }}

--- a/workflow-templates/yarn-deploy.yml
+++ b/workflow-templates/yarn-deploy.yml
@@ -194,6 +194,10 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.0.0-b02
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configurationJson: |
+            {
+              "pr_template": "- #{{TITLE}} (by @#{{AUTHOR}} in ##{{NUMBER}})"
+            }
           outputFile: release_changelog.md
           fromTag: ${{ steps.versioning.outputs.buildFromTag }}
           toTag: ${{ steps.versioning.outputs.relTag }}

--- a/workflow-templates/yarn2-deploy.yml
+++ b/workflow-templates/yarn2-deploy.yml
@@ -194,6 +194,10 @@ jobs:
         uses: mikepenz/release-changelog-builder-action@v4.0.0-b02
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          configurationJson: |
+            {
+              "pr_template": "- #{{TITLE}} (by @#{{AUTHOR}} in ##{{NUMBER}})"
+            }
           outputFile: release_changelog.md
           fromTag: ${{ steps.versioning.outputs.buildFromTag }}
           toTag: ${{ steps.versioning.outputs.relTag }}


### PR DESCRIPTION
- update myplant gh actions version
- remove AUTO_RELEASE
- creates a changelog (inserts Jira Links) and updates the prerelease/release
  - first release: first commit to first release
  - prereleases: last pre- or release before the new created prerelease
  - releases: last release to new created release
- Gradle and Yarn retag docker image (only working if prereleases are created)
  - check if release tag and the latest prerelease are on same rev, retag if true