### PR TITLE
chore: adding ref for auto-update

### DIFF
--- a/workflow-templates/common-auto-update.yml
+++ b/workflow-templates/common-auto-update.yml
@@ -34,6 +34,7 @@ jobs:
           repository: myplant-io/.github
           token: ${{ secrets.CI_PAT }}
           path: source
+          ref: v0.7.3
 
       - name: Checkout git repository
         if: startsWith(github.event_name , 'pull_request') == false


### PR DESCRIPTION
up until now the auto-update always used the default branch of this repo here.
That really does not make a lot of sense :)