### PR TITLE
fix: use cdxgen latest version and only audit required dependencies

### DIFF
--- a/workflow-templates/docker-deploy.yml
+++ b/workflow-templates/docker-deploy.yml
@@ -229,6 +229,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [

--- a/workflow-templates/dotnet-deploy.yml
+++ b/workflow-templates/dotnet-deploy.yml
@@ -196,6 +196,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [

--- a/workflow-templates/gradle-deploy.yml
+++ b/workflow-templates/gradle-deploy.yml
@@ -235,6 +235,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [

--- a/workflow-templates/python-deploy.yml
+++ b/workflow-templates/python-deploy.yml
@@ -244,6 +244,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [

--- a/workflow-templates/yarn-dependency-check.yml
+++ b/workflow-templates/yarn-dependency-check.yml
@@ -113,12 +113,9 @@ jobs:
         if: steps.node_modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --ignore-optional
 
-      - name: Install yarn-add-no-save (if not already installed)
-        run: yarn add --dev yarn-add-no-save
-
       - name: Install yarn-audit-html report
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
-        run: yarn add-no-save yarn-audit-html --ignore-optional
+        run: yarn add --dev yarn-audit-html --ignore-optional
 
       - name: Perform yarn audit
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
@@ -133,10 +130,13 @@ jobs:
           path: yarn-audit.html
 
       - name: Install @cyclonedx/cdxgen
-        run: yarn add-no-save @cyclonedx/cdxgen
+        run: yarn add --dev @cyclonedx/cdxgen@v8.6.2
 
       - name: Create SBOM using cyclonedx
-        run: yarn run --no-install cdxgen --output bom.xml
+        run: yarn run --no-install cdxgen --output bom.xml --required-only
+
+      - name: Revert lockfile changes (caused by cdxgen and yarn-audit-html install)
+        run: git checkout -- package.json yarn.lock
 
       - name: Upload SBOM artifact
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}

--- a/workflow-templates/yarn-dependency-check.yml
+++ b/workflow-templates/yarn-dependency-check.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install yarn-audit-html report
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
-        run: yarn add --dev yarn-audit-html --ignore-optional
+        run: yarn add --dev --ignore-workspace-root-check yarn-audit-html --ignore-optional
 
       - name: Perform yarn audit
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
@@ -130,7 +130,7 @@ jobs:
           path: yarn-audit.html
 
       - name: Install @cyclonedx/cdxgen
-        run: yarn add --dev @cyclonedx/cdxgen@v8.6.2
+        run: yarn add --dev --ignore-workspace-root-check @cyclonedx/cdxgen@v8.6.2
 
       - name: Create SBOM using cyclonedx
         run: yarn run --no-install cdxgen --output bom.xml --required-only

--- a/workflow-templates/yarn-deploy.yml
+++ b/workflow-templates/yarn-deploy.yml
@@ -221,6 +221,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [

--- a/workflow-templates/yarn2-dependency-check.yml
+++ b/workflow-templates/yarn2-dependency-check.yml
@@ -119,10 +119,12 @@ jobs:
         run: yarn add --dev npm-audit-html --ignore-optional
 
       - name: Perform audit
+        if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
         continue-on-error: true
         run: yarn npm audit --environment production --severity ${SECURITY_LEVEL} --json | yarn npm-audit-html
 
       - name: Upload audit report artifact
+        if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           if-no-files-found: error

--- a/workflow-templates/yarn2-dependency-check.yml
+++ b/workflow-templates/yarn2-dependency-check.yml
@@ -111,12 +111,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Install dependencies (if not previously cached)
-        # if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - name: Install dependencies
         run: yarn install --immutable
 
-      #      - name: Install html report
-      #        run: npm install --no-package-lock --no-save npm-audit-html
+      - name: Install npm-audit-html report
+        if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}
+        run: yarn add --dev npm-audit-html --ignore-optional
 
       - name: Perform audit
         continue-on-error: true
@@ -129,13 +129,14 @@ jobs:
           name: audit-report
           path: npm-audit.html
 
-      # needs to be added by hand for now
-      #      - name: Install @cyclonedx/cdxgen
-      #        run: yarn add-no-save @cyclonedx/cdxgen
-      # or:       run: yarn add --dev @cyclonedx/cdxgen
+      - name: Install @cyclonedx/cdxgen
+        run: yarn add --dev @cyclonedx/cdxgen@v8.6.2
 
       - name: Create SBOM using cyclonedx
-        run: yarn cdxgen --output bom.xml
+        run: yarn cdxgen --output bom.xml --required-only
+
+      - name: Revert lockfile changes (caused by cdxgen and npm-audit-html install)
+        run: git checkout -- package.json yarn.lock
 
       - name: Upload SBOM artifact
         if: ${{ env.VERBOSE_ARTIFACT_UPLOAD == 'true' }}

--- a/workflow-templates/yarn2-deploy.yml
+++ b/workflow-templates/yarn2-deploy.yml
@@ -221,6 +221,10 @@ jobs:
                     "deps",
                     "dep"
                   ]
+                },
+                {
+                  "title": "## 🌀 Miscellaneous",
+                  "labels": []
                 }
               ],
               "label_extractor": [


### PR DESCRIPTION
- [x] fix cdxgen verison to 8.6.2
- [x] run cdxgen with "--required-only" flag
- [x] get rid of yarn-add-no-save (but use git checkout after installation/runs)