### PR TITLE
feat: optional workflows

### DIFF
--- a/optional-workflows/combine-dependabot-pr.yml
+++ b/optional-workflows/combine-dependabot-pr.yml
@@ -1,0 +1,156 @@
+# Will combine green dependabot PRs into one and closes all combined after merge.
+# https://github.com/hrvey/combine-prs-workflow
+
+
+name: 'Combine dependabot PRs'
+
+# Controls when the action will run - in this case triggered manually
+on:
+  workflow_dispatch:
+    inputs:
+      branchPrefix:
+        description: 'Branch prefix to find combinable PRs based on'
+        required: true
+        default: 'dependabot'
+      mustBeGreen:
+        description: 'Only combine PRs that are green (status is success). Set to false if repo does not run checks'
+        type: boolean
+        required: true
+        default: true
+      combineBranchName:
+        description: 'Name of the branch to combine PRs into'
+        required: true
+        default: 'combine-prs-branch'
+      ignoreLabel:
+        description: 'Exclude PRs with this label'
+        required: true
+        default: 'nocombine'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "combine-prs"
+  combine-prs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/github-script@v6
+        id: create-combined-pr
+        name: Create Combined PR
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pulls = await github.paginate('GET /repos/:owner/:repo/pulls', {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            let branchesAndPRStrings = [];
+            let baseBranch = null;
+            let baseBranchSHA = null;
+            for (const pull of pulls) {
+              const branch = pull['head']['ref'];
+              console.log('Pull for branch: ' + branch);
+              if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
+                console.log('Branch matched prefix: ' + branch);
+                let statusOK = true;
+                if(${{ github.event.inputs.mustBeGreen }}) {
+                  console.log('Checking green status: ' + branch);
+                  const stateQuery = `query($owner: String!, $repo: String!, $pull_number: Int!) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number:$pull_number) {
+                        commits(last: 1) {
+                          nodes {
+                            commit {
+                              statusCheckRollup {
+                                state
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }`
+                  const vars = {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pull['number']
+                  };
+                  const result = await github.graphql(stateQuery, vars);
+                  const [{ commit }] = result.repository.pullRequest.commits.nodes;
+                  const state = commit.statusCheckRollup.state
+                  console.log('Validating status: ' + state);
+                  if(state != 'SUCCESS') {
+                    console.log('Discarding ' + branch + ' with status ' + state);
+                    statusOK = false;
+                  }
+                }
+                console.log('Checking labels: ' + branch);
+                const labels = pull['labels'];
+                for(const label of labels) {
+                  const labelName = label['name'];
+                  console.log('Checking label: ' + labelName);
+                  if(labelName == '${{ github.event.inputs.ignoreLabel }}') {
+                    console.log('Discarding ' + branch + ' with label ' + labelName);
+                    statusOK = false;
+                  }
+                }
+                if (statusOK) {
+                  console.log('Adding branch to array: ' + branch);
+                  const prString = '#' + pull['number'] + ' ' + pull['title'];
+                  branchesAndPRStrings.push({ branch, prString });
+                  baseBranch = pull['base']['ref'];
+                  baseBranchSHA = pull['base']['sha'];
+                }
+              }
+            }
+            if (branchesAndPRStrings.length == 0) {
+              core.setFailed('No PRs/branches matched criteria');
+              return;
+            }
+            try {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/heads/' + '${{ github.event.inputs.combineBranchName }}',
+                sha: baseBranchSHA
+              });
+            } catch (error) {
+              console.log(error);
+              core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
+              return;
+            }
+            
+            let combinedPRs = [];
+            let mergeFailedPRs = [];
+            for(const { branch, prString } of branchesAndPRStrings) {
+              try {
+                await github.rest.repos.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: '${{ github.event.inputs.combineBranchName }}',
+                  head: branch,
+                });
+                console.log('Merged branch ' + branch);
+                combinedPRs.push(prString);
+              } catch (error) {
+                console.log('Failed to merge branch ' + branch);
+                mergeFailedPRs.push(prString);
+              }
+            }
+            
+            console.log('Creating combined PR');
+            const combinedPRsString = combinedPRs.join('\n');
+            let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;
+            if(mergeFailedPRs.length > 0) {
+              const mergeFailedPRsString = mergeFailedPRs.join('\n');
+              body += '\n\n⚠️ The following PRs were left out due to merge conflicts:\n' + mergeFailedPRsString
+            }
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Combined PR',
+              head: '${{ github.event.inputs.combineBranchName }}',
+              base: baseBranch,
+              body: body
+            });

--- a/optional-workflows/create-release-branch.yml
+++ b/optional-workflows/create-release-branch.yml
@@ -1,12 +1,12 @@
 # When triggered, it will use the source branch to create a new branch release/v{version} from it, where
 # version is derived to the latest release tag bumped using conventional commits.
-# Example: if commit starts with "feat: ", 1.1.1 is bumped to 1.2.1
+# Example: if commit starts with "feat: ", 1.1.1 is bumped to 1.2.1 (https://github.com/mathieudutour/github-tag-action#bumping)
 #
 # If this branch already exists, the source branch will be merged on top of it
 #
 # HINT: It is possible to merge directly into those feature branches without negative impact to the pipeline
 
-name: "Stage branch for release"
+name: "Create Pre/Release branch"
 
 on:
   workflow_dispatch:
@@ -31,6 +31,7 @@ jobs:
           tag_prefix: "v"
           dry_run: true
           append_to_pre_release_tag: false
+
       - name: Determine release branch name
         id: branch-names
         env:
@@ -40,6 +41,7 @@ jobs:
           echo "::set-output name=next-release::$nextRelease"
           echo "::set-output name=name::release/$nextRelease"
           echo "::set-output name=source-branch::${GITHUB_REF#refs/heads/}"
+
       - name: Look for existing branch
         id: branch-exists
         env:
@@ -52,6 +54,7 @@ jobs:
           else
               echo "::set-output name=exists::true"
           fi
+
       - uses: peterjgrainger/action-create-branch@v2.0.1
         if:  ${{ steps.branch-exists.outputs.exists == 'false' }}
         name: Create branch for release cycle
@@ -60,6 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CI_PAT }}
         with:
           branch: ${{ steps.branch-names.outputs.name }}
+
       - name: Prepare commit message
         if:  ${{ steps.branch-exists.outputs.exists == 'true' }}
         id: commit-message
@@ -67,6 +71,7 @@ jobs:
           BRANCH: ${{ steps.branch-names.outputs.source-branch }}
           RELEASE: ${{ steps.branch-names.outputs.next-release }}
         run: echo "::set-output name=message::Merge branch $BRANCH into release $RELEASE"
+
       - name: Merge for PreRelease
         if:  ${{ steps.branch-exists.outputs.exists == 'true' }}
         uses: tukasz/direct-merge-action@master

--- a/optional-workflows/create-release-branch.yml
+++ b/optional-workflows/create-release-branch.yml
@@ -1,0 +1,78 @@
+# When triggered, it will use the source branch to create a new branch release/v{version} from it, where
+# version is derived to the latest release tag bumped using conventional commits.
+# Example: if commit starts with "feat: ", 1.1.1 is bumped to 1.2.1
+#
+# If this branch already exists, the source branch will be merged on top of it
+#
+# HINT: It is possible to merge directly into those feature branches without negative impact to the pipeline
+
+name: "Stage branch for release"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  start-release-cycle:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Display receiver
+        run: echo ${GITHUB_REF#refs/heads/}
+
+      - name: Analyze repo
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: "v"
+          dry_run: true
+          append_to_pre_release_tag: false
+      - name: Determine release branch name
+        id: branch-names
+        env:
+          preRelTag: ${{ steps.tag_version.outputs.new_tag }}
+        run: |
+          nextRelease=${preRelTag%-*}
+          echo "::set-output name=next-release::$nextRelease"
+          echo "::set-output name=name::release/$nextRelease"
+          echo "::set-output name=source-branch::${GITHUB_REF#refs/heads/}"
+      - name: Look for existing branch
+        id: branch-exists
+        env:
+          branch: ${{ steps.branch-names.outputs.name }}
+        run: |
+          branchExists=$(git ls-remote --heads origin ${branch})
+
+          if [[ -z ${branchExists} ]]; then
+              echo "::set-output name=exists::false"
+          else
+              echo "::set-output name=exists::true"
+          fi
+      - uses: peterjgrainger/action-create-branch@v2.0.1
+        if:  ${{ steps.branch-exists.outputs.exists == 'false' }}
+        name: Create branch for release cycle
+        env:
+          # Use another token then GITHUB_TOKEN to trigger subsequent workflows
+          GITHUB_TOKEN: ${{ secrets.CI_PAT }}
+        with:
+          branch: ${{ steps.branch-names.outputs.name }}
+      - name: Prepare commit message
+        if:  ${{ steps.branch-exists.outputs.exists == 'true' }}
+        id: commit-message
+        env:
+          BRANCH: ${{ steps.branch-names.outputs.source-branch }}
+          RELEASE: ${{ steps.branch-names.outputs.next-release }}
+        run: echo "::set-output name=message::Merge branch $BRANCH into release $RELEASE"
+      - name: Merge for PreRelease
+        if:  ${{ steps.branch-exists.outputs.exists == 'true' }}
+        uses: tukasz/direct-merge-action@master
+        with:
+          # Use another token then GITHUB_TOKEN to trigger subsequent workflows
+          GITHUB_TOKEN: ${{ secrets.CI_PAT }}
+          source-branch: ${{ steps.branch-names.outputs.source-branch }}
+          target-branch: ${{ steps.branch-names.outputs.name }}
+          commit-message: ${{ steps.commit-message.outputs.message }}


### PR DESCRIPTION
2 optional workflows for ease of copying:

combine-dependabot-pr: combines all "green" dependabot PRs into one branch to merge all at once, closes all merged PRs afterwards (run manually)
create-release-branch: creates a new release branch and uses versioning from conventional commits (run manually)