### PR TITLE
feat: pass nvd.apiKey to gradle

### DIFF
--- a/workflow-templates/gradle-dependency-check.yml
+++ b/workflow-templates/gradle-dependency-check.yml
@@ -137,6 +137,7 @@ jobs:
           arguments: |
             ${{ env.GRADLE_DEPENDENCY_CHECK_TASK }} -Pversion=${{ env.VERSION }}
             -Pcyclonedx.includeBomSerialNumber=false
+            -Pnvd.apiKey=${{ secrets.NVD_API_KEY }}
 
       - name: Post process dependency check bom
         run: sed -i "s/type=jar//g" build/reports/bom.xml


### PR DESCRIPTION
needed, so that the dependencyCheckAnalyze task can then use the nvd.apiKey (value is stored in GH secrets)