### PR TITLE
fix: fail dependency check if gradle fails to do it

### DIFF
--- a/workflow-templates/gradle-dependency-check.yml
+++ b/workflow-templates/gradle-dependency-check.yml
@@ -132,7 +132,6 @@ jobs:
 
       - name: Dependency check with gradle
         uses: gradle/gradle-build-action@v2
-        continue-on-error: true
         with:
           arguments: |
             ${{ env.GRADLE_DEPENDENCY_CHECK_TASK }} -Pversion=${{ env.VERSION }}


### PR DESCRIPTION
- why did we want to continue here? does not make sense to me...