### PR TITLE
fix: always login to ecr on image deploy

### DIFF
--- a/workflow-templates/prefect-deploy.yml
+++ b/workflow-templates/prefect-deploy.yml
@@ -310,12 +310,10 @@ jobs:
           version: ${{ env.VERSION }}
 
       - name: Login to Amazon ECR
-        if: env.RETAG == 'false' && steps.check-docker-registry.outputs.imageExists == 'false'
         id: aws-login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Docker login (to AWS ECR)
-        if: env.RETAG == 'false' && steps.check-docker-registry.outputs.imageExists == 'false'
         uses: docker/login-action@v3
         with:
           registry: ${{ steps.aws-login-ecr.outputs.registry }}


### PR DESCRIPTION
to get the IMAGE_TAG we always need to login to ecr