### PR TITLE
fix: use general javaVersion task

### DIFF
--- a/workflow-templates/gradle-dependency-check.yml
+++ b/workflow-templates/gradle-dependency-check.yml
@@ -138,7 +138,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Get java version from gradle
-        run: echo "JAVA_VERSION=$(./gradlew -q :javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
+        run: echo "JAVA_VERSION=$(./gradlew -q javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
 
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/workflow-templates/gradle-deploy.yml
+++ b/workflow-templates/gradle-deploy.yml
@@ -313,7 +313,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Get java version from gradle
-        run: echo "JAVA_VERSION=$(./gradlew -q :javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
+        run: echo "JAVA_VERSION=$(./gradlew -q javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
 
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/workflow-templates/gradle-sonarqube.yml
+++ b/workflow-templates/gradle-sonarqube.yml
@@ -162,7 +162,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Get java version from gradle
-        run: echo "JAVA_VERSION=$(./gradlew -q :javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
+        run: echo "JAVA_VERSION=$(./gradlew -q javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
 
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4

--- a/workflow-templates/gradle-test.yml
+++ b/workflow-templates/gradle-test.yml
@@ -108,7 +108,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Get java version from gradle
-        run: echo "JAVA_VERSION=$(./gradlew -q :javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
+        run: echo "JAVA_VERSION=$(./gradlew -q javaVersion -Dorg.gradle.java.home=$JAVA_HOME_17_X64 | tail -n 1)" >> ${GITHUB_ENV}
 
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
the :javaVersion is much faster, but it does not always work, so lets go back to javaVersion (without the colon at the beginning)