### PR TITLE
fix: test for gradle project broken

### DIFF
--- a/workflow-templates/common-auto-update.yml
+++ b/workflow-templates/common-auto-update.yml
@@ -83,12 +83,16 @@ jobs:
       - name: Set project type to gradle
         run: echo PROJECT_TYPE="unknown" >> ${GITHUB_ENV}
 
-      - name: Test project-type (for gradle)
+      - name: Test project-type (for gradle) (old gradle wrapper)
+        id: determine-type-gradle-old
+        run: echo cnt_validations=$(ls ${{ env.TARGET_DIR }}/deploy* | xargs grep -w 'gradle/wrapper-validation-action' | wc -l) >> ${GITHUB_OUTPUT}
+
+      - name: Test project-type (for gradle) (new gradle wrapper)
         id: determine-type-gradle
         run: echo cnt_validations=$(ls ${{ env.TARGET_DIR }}/deploy* | xargs grep -w 'gradle/actions/wrapper-validation' | wc -l) >> ${GITHUB_OUTPUT}
 
       - name: Set project type to gradle
-        if: steps.determine-type-gradle.outputs.cnt_validations != '0'
+        if: steps.determine-type-gradle.outputs.cnt_validations != '0' || steps.determine-type-gradle-old.outputs.cnt_validations != '0'
         run: echo PROJECT_TYPE=gradle >> ${GITHUB_ENV}
 
       - name: Test project-type (for yarn classic)


### PR DESCRIPTION
https://github.com/myplant-io/.github/commit/f00a8e43b9aa0357fcfc57e87c68e7e22e690873

this change broke the auto-update for gradle and deploys common-sonarqube for example:
https://github.com/myplant-io/maintenance-distributors/pull/178

i am not exactly sure how it would work on old repos if we would not keep the check for the old gradle wrapper