### PR TITLE
fix: DD-49216 execute all tests recursively to calculate test coverage for Go projects

### DIFF
--- a/workflow-templates/go-sonarqube.yml
+++ b/workflow-templates/go-sonarqube.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           go mod tidy
           go build .
-          go test -coverprofile=coverage.out . > testresults.out
+          go test -coverprofile=coverage.out ./... > testresults.out
 
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v8


### PR DESCRIPTION
This should fix the code coverage calculation on go