### PR TITLE
fix/DD 49216 GoTestCoverage2

### DIFF
--- a/workflow-templates/go-sonarqube.yml
+++ b/workflow-templates/go-sonarqube.yml
@@ -182,6 +182,7 @@ jobs:
           -Dsonar.projectKey=${{ env.SONAR_KEY }}
           -Dsonar.projectName=${{ env.COMPONENT_NAME }}
           -Dsonar.projectVersion=${{ env.SONAR_BASE_VERSION }}
+          -Dsonar.exclusions=**/*_test.go
           -Dsonar.go.coverage.reportPaths=coverage.out
           -Dsonar.go.tests.reportPaths=testresults.out
           -Dsonar.qualitygate.wait=true

--- a/workflow-templates/go-sonarqube.yml
+++ b/workflow-templates/go-sonarqube.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           go mod tidy
           go build .
-          go test -coverprofile=coverage.out . > testresults.out
+          go test -coverprofile=coverage.out ./... > testresults.out
 
       - name: Setup sonarqube
         uses: warchant/setup-sonar-scanner@v8


### PR DESCRIPTION
See [this PR](https://github.com/myplant-io/maintenance-fleet-program-event-creator/pull/47) where this change removed the need to cover _test files.
