### PR TITLE
fix: DD-49398 exclude _test.go files from coverage calculation (also for PR runs)

### DIFF
--- a/workflow-templates/go-sonarqube.yml
+++ b/workflow-templates/go-sonarqube.yml
@@ -200,6 +200,7 @@ jobs:
           -Dsonar.pullrequest.base=${{ github.base_ref }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
           -Dsonar.pullrequest.key=${{ github.event.number }}
+          -Dsonar.exclusions=**/*_test.go
           -Dsonar.go.coverage.reportPaths=coverage.out
           -Dsonar.go.tests.reportPaths=testresults.out
           -Dsonar.qualitygate.wait=true


### PR DESCRIPTION
For non-PR it was previously done here, but missing for Pull Requests