### PR TITLE
fix: allow write-all permission for dependabot on test action

### DIFF
--- a/workflow-templates/gradle-test.yml
+++ b/workflow-templates/gradle-test.yml
@@ -15,6 +15,8 @@ on:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:
 
+permissions: write-all # allows dependabot to upload with dorny/test-reporter
+
 jobs:
   validateAndTest:
     name: 'Job: Validate and test'


### PR DESCRIPTION
Saw quite some action runs in the last time where our test-results reporter would fail with some missing permissions (like this here: ![image](https://github.com/user-attachments/assets/66951460-4184-466a-b9cc-caf2b3dfebbb))

This happens only in dependabot runs and not in regular runs.
Did some reading and found out that the default used GITHUB_TOKEN has write-all permission and the default dependabot run uses a GITHUB_TOKEN with read-all permissions (without writing permission)

So the added line will also allow dependabot to write test reports and append them as artifact to a GitHub action.
This has also been discussed with out cyber-security Officer KlausB and is approved also from that side :-)