### PR TITLE
fix: do not fail fast

### DIFF
--- a/workflow-templates/gradle-dependency-check.yml
+++ b/workflow-templates/gradle-dependency-check.yml
@@ -209,6 +209,7 @@ jobs:
     runs-on: [self-hosted-standard]
 
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         project-name: ${{fromJSON(needs.setup.outputs.project-names)}}

--- a/workflow-templates/gradle-sonarqube.yml
+++ b/workflow-templates/gradle-sonarqube.yml
@@ -230,6 +230,7 @@ jobs:
     runs-on: [ubuntu-latest]
 
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         project-name: ${{fromJSON(needs.setup.outputs.project-names)}}


### PR DESCRIPTION
so that we sent results for all subprojects to sonar (and dependency-check), even if a previous job failed