### PR TITLE
fix: make python sonar exclusion more generic

### DIFF
--- a/workflow-templates/python-sonarqube.yml
+++ b/workflow-templates/python-sonarqube.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Determine source folders
         run: |
           echo PROJECT_SOURCES=$(find . -path './src' -o -path './task' -o -path './app' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
-          echo PROJECT_TEST_SOURCES="tests/" >> ${GITHUB_ENV}
+          echo PROJECT_TEST_SOURCES=$(find . -path './test' -o -path './tests' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
 
       - name: Check for test availability (with pip)
         id: check_test_pip
@@ -313,7 +313,7 @@ jobs:
           -Dsonar.projectVersion=${{ env.SONAR_BASE_VERSION }}
           -Dsonar.sources=${{ env.PROJECT_SOURCES }}
           -Dsonar.tests=${{ env.PROJECT_TEST_SOURCES }}
-          -Dsonar.coverage.exclusions=tests/**
+          -Dsonar.coverage.exclusions=${{ env.PROJECT_TEST_SOURCES }}/**
           -Dsonar.python.coverage.reportPaths=./coverage.xml
           -Dsonar.qualitygate.wait=true
 
@@ -332,6 +332,6 @@ jobs:
           -Dsonar.pullrequest.key=${{ github.event.number }}
           -Dsonar.sources=${{ env.PROJECT_SOURCES }}
           -Dsonar.tests=${{ env.PROJECT_TEST_SOURCES }}
-          -Dsonar.coverage.exclusions=tests/**
+          -Dsonar.coverage.exclusions=${{ env.PROJECT_TEST_SOURCES }}/**
           -Dsonar.python.coverage.reportPaths=./coverage.xml
           -Dsonar.qualitygate.wait=true


### PR DESCRIPTION
Makes exclusions for tests more generic and allows test paths to be named "tests" or "test".