### PR TITLE
fix: activate validate and test on master

### DIFF
--- a/workflow-templates/dotnetCore-test.yml
+++ b/workflow-templates/dotnetCore-test.yml
@@ -10,7 +10,7 @@ name: Test (with dotnet directly)
 
 on:
   pull_request:
-    branches: [develop, release/**, bugfix/**, hotfix/**]
+    branches: [main, master, develop, release/**, bugfix/**, hotfix/**]
     paths-ignore:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:

--- a/workflow-templates/gradle-test.yml
+++ b/workflow-templates/gradle-test.yml
@@ -10,7 +10,7 @@ name: Validate and test
 
 on:
   pull_request:
-    branches: [develop, release/**, bugfix/**, hotfix/**]
+    branches: [main, master, develop, release/**, bugfix/**, hotfix/**]
     paths-ignore:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:

--- a/workflow-templates/python-test.yml
+++ b/workflow-templates/python-test.yml
@@ -7,7 +7,7 @@ name: Validate and test
 
 on:
   pull_request:
-    branches: [develop, release/**, bugfix/**, hotfix/**]
+    branches: [main, master, develop, release/**, bugfix/**, hotfix/**]
     paths-ignore:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:

--- a/workflow-templates/yarn-test.yml
+++ b/workflow-templates/yarn-test.yml
@@ -10,7 +10,7 @@ name: Validate and test
 
 on:
   pull_request:
-    branches: [develop, release/**, bugfix/**, hotfix/**]
+    branches: [main, master, develop, release/**, bugfix/**, hotfix/**]
     paths-ignore:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:

--- a/workflow-templates/yarn2-test.yml
+++ b/workflow-templates/yarn2-test.yml
@@ -10,7 +10,7 @@ name: Validate and test
 
 on:
   pull_request:
-    branches: [develop, release/**, bugfix/**, hotfix/**]
+    branches: [main, master, develop, release/**, bugfix/**, hotfix/**]
     paths-ignore:
       - '.github/workflows/*auto-update*'
   workflow_dispatch:


### PR DESCRIPTION
Need to activate "validate and master" to be able to have that as a required check for develop (cause the trigger is on the source branch and not for the target one like we use in the scm-control repo definitions).