### PR TITLE
chore: Allow "Task" folder as sonar source for python

### DIFF
--- a/workflow-templates/python-sonarqube.yml
+++ b/workflow-templates/python-sonarqube.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Determine source folders
         run: |
-          echo PROJECT_SOURCES=$(find . -path './src' -o -path './task' -o -path './app' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
+          echo PROJECT_SOURCES=$(find . -path './src' -o -path './task' -o -path './Task' -o -path './app' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
           echo PROJECT_TEST_SOURCES=$(find . -path './test' -o -path './tests' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
 
       - name: Check for test availability (with pip)

--- a/workflow-templates/python-sonarqube.yml
+++ b/workflow-templates/python-sonarqube.yml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Determine source folders
         run: |
-          echo PROJECT_SOURCES=$(find . -path './src' -o -path './task' -o -path './Task' -o -path './app' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
+          echo PROJECT_SOURCES=$(find . -path './src' -o -path './task' -o -path './Task' -o -path './app' -o -path './dashboard' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
           echo PROJECT_TEST_SOURCES=$(find . -path './test' -o -path './tests' | sed "s/^\.\///" | xargs | tr ' ' ',') >> ${GITHUB_ENV}
 
       - name: Check for test availability (with pip)


### PR DESCRIPTION
Some Analytics projects are using "Task" instead of "task" ...