### PR TITLE
fix: always update version in pyproject.toml

### DIFF
--- a/workflow-templates/python-deploy.yml
+++ b/workflow-templates/python-deploy.yml
@@ -537,7 +537,7 @@ jobs:
           endpoint: buildx-context
 
       - name: Update version in pyproject file
-        if: steps.check_file_pyproject.outputs.files_exists == 'true' && (needs.setup.outputs.is-release == 'true' || needs.setup.outputs.is-prerelease == 'true')
+        if: steps.check_file_pyproject.outputs.files_exists == 'true'
         run: sed -i 's/^version\s=\s.*[0-9]\?/version = "${{ needs.setup.outputs.version }}"/g' pyproject.toml
 
       - name: Validate base image (golden image check)


### PR DESCRIPTION
uv build steps also depend on the correct version being in the pyproject.toml file, as they use that to determine the build version. I assume Poetry follows a similar logic. Didn't want to make the condition more complex by adding a bunch of or branches, and the operation is essentially free in terms of compute, so I figured this was the simplest solution. If you foresee issues with this approach, I can amend the condition