### PR TITLE
chore: switch java distribution to temurin

### DIFF
--- a/workflow-templates/gradle-dependency-check.yml
+++ b/workflow-templates/gradle-dependency-check.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Determine number of gradle (sub)projects
@@ -319,7 +319,7 @@ jobs:
       - name: Prepare java ${{ needs.setup.outputs.java-version }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ needs.setup.outputs.java-version }}
 
       - name: Set env 'GRADLE_DEPENDENCY_CHECK_TASK' (fallback to default)

--- a/workflow-templates/gradle-deploy.yml
+++ b/workflow-templates/gradle-deploy.yml
@@ -404,7 +404,7 @@ jobs:
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Configure AWS credentials

--- a/workflow-templates/gradle-sonarqube.yml
+++ b/workflow-templates/gradle-sonarqube.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Determine number of gradle (sub)projects
@@ -350,7 +350,7 @@ jobs:
       - name: Prepare java ${{ needs.setup.outputs.java-version }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ needs.setup.outputs.java-version }}
 
       - name: Configure AWS credentials (to enable test to download containers)
@@ -432,7 +432,7 @@ jobs:
         if: needs.setup.outputs.java-version == '8' || needs.setup.outputs.java-version == '11'
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 17
 
       - name: Fetch repository topics

--- a/workflow-templates/gradle-test.yml
+++ b/workflow-templates/gradle-test.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Prepare java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Configure AWS credentials (to enable test to download containers)


### PR DESCRIPTION
Should fix:
```
AdoptOpenJDK has moved to Eclipse Temurin https://github.com/actions/setup-java#supported-distributions please consider changing to the 'temurin' distribution type in your setup-java configuration.
```

[Supported Distributions](https://github.com/actions/setup-java#supported-distributions)